### PR TITLE
Update torchvision version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ CMD source ~/.bashrc
 RUN conda install python=3.9
 
 # install pytorch and other things
-RUN conda install pytorch=1.9.0 torchvision=0.2.2 torchaudio=0.9.0 cudatoolkit=10.2 -c pytorch -y
+RUN conda install pytorch=1.9.0 torchvision=0.10.0 torchaudio=0.9.0 cudatoolkit=10.2 -c pytorch -y
 RUN pip install torchmetrics==0.6.0
 RUN conda install -c conda-forge firefox geckodriver
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,7 @@ WORKDIR nuplan-devkit
 RUN git checkout 3c4f5b8dcd517b27cfd258915ca5fe5c54e3cb0c
 RUN sed -i "s|torch==|#torch==|g" requirements.txt && sed -i "s|torchvision==|#torchvision==|g" requirements.txt
 RUN pip install -e .
+RUN pip install protobuf==3.20.0
 
 # install rewards deterioration detection
 WORKDIR /home/p-qad/p-qad


### PR DESCRIPTION
The conda pytorch build failed with `torchvision=0.2.2`, I updated it to `0.10.0`. Also there was a conflict with the protobuf version and pytorch lightning, I added a line to downgrade protobuf.